### PR TITLE
add cross-feature navigation from Order → HomeDetail

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,20 @@ graph TD
 
 ## 🔄 Feature-to-Feature Navigation & Internal Screen Routing
 
+The project supports type-safe cross-feature navigation using Activity-based sealed contracts, while internal navigation within a feature still uses Fragment-based navigation.
+
+Internal Feature Navigation:
+Fragments navigate via NavController
+
+Safe args + navigation graphs are used per feature
+
+Cross-Feature Navigation:
+Each feature exposes a sealed Navigator contract
+
+Intent is built from the consumer using navigator.intentFor(...)
+
+Data is passed via IDs only (e.g. homeId: Int) and resolved inside ViewModels using SavedStateHandle
+
 ### ✅ Internal Navigation (within a feature)
 
 Each feature defines and owns its own **navigation graph**:

--- a/feature/home/impl/src/main/AndroidManifest.xml
+++ b/feature/home/impl/src/main/AndroidManifest.xml
@@ -7,6 +7,10 @@
             android:exported="true"
             android:label="Home Feature"
             android:theme="@style/Theme.Pluggo" />
+        <activity
+            android:name=".ui.homedetail.HomeDetailActivity"
+            android:exported="false"
+            android:theme="@style/Theme.Pluggo" />
     </application>
 
 </manifest>

--- a/feature/home/impl/src/main/java/com.example.feature.home.impl/ui/homedetail/HomeDetailFragment.kt
+++ b/feature/home/impl/src/main/java/com.example.feature.home.impl/ui/homedetail/HomeDetailFragment.kt
@@ -24,8 +24,22 @@ class HomeDetailFragment : Fragment() {
             setContent {
                 HomeDetailScreen(
                     viewModel = viewModel,
-                    onBackClick = { findNavController().popBackStack() })
+                    onBackClick = {
+                        val navController = try {
+                            findNavController()
+                        } catch (e: IllegalStateException) {
+                            null
+                        }
+
+                        if (navController?.previousBackStackEntry != null) {
+                            navController.popBackStack()
+                        } else {
+                            requireActivity().onBackPressedDispatcher.onBackPressed()
+                        }
+                    }
+                )
             }
         }
     }
+
 }

--- a/feature/order/impl/build.gradle.kts
+++ b/feature/order/impl/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)
     alias(libs.plugins.dagger.hilt.android)
+    alias(libs.plugins.androidx.navigation.safe.args)
 }
 
 android {
@@ -33,6 +34,7 @@ android {
 
 dependencies {
     api(project(":feature:order:api"))
+    implementation(project(":feature:home:api"))
     implementation(project(":core"))
 
     api(libs.kotlinx.coroutines.core)

--- a/feature/order/impl/src/main/java/com/example/feature/order/impl/ui/orderlist/OrderFragment.kt
+++ b/feature/order/impl/src/main/java/com/example/feature/order/impl/ui/orderlist/OrderFragment.kt
@@ -1,27 +1,42 @@
 package com.example.feature.order.impl.ui.orderlist
 
 import android.os.Bundle
-import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
+import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import com.example.feature.home.api.HomeNavigator
 import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class OrderFragment : Fragment() {
 
     private val viewModel: OrderViewModel by viewModels()
 
+    @Inject
+    lateinit var homeNavigator: HomeNavigator
+
     override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
+        inflater: LayoutInflater,
+        container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        return TextView(requireContext()).apply {
-            text = "Temporary Order Screen"
-            gravity = Gravity.CENTER
+        return ComposeView(requireContext()).apply {
+            setContent {
+                OrderScreen(
+                    viewModel = viewModel,
+                    onNavigate = { destination ->
+                        val intent = homeNavigator.intentFor(
+                            context = requireContext(),
+                            destination = destination
+                        )
+                        startActivity(intent)
+                    }
+                )
+            }
         }
     }
 }

--- a/feature/order/impl/src/main/java/com/example/feature/order/impl/ui/orderlist/OrderScreen.kt
+++ b/feature/order/impl/src/main/java/com/example/feature/order/impl/ui/orderlist/OrderScreen.kt
@@ -1,14 +1,74 @@
 package com.example.feature.order.impl.ui.orderlist
 
-/*
-@Composable
-fun OrderScreen(viewModel: OrderViewModel) {
-    val uiState by viewModel.uiState.collectAsState()
-    OrderScreenContent(uiState)
-}
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Button
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.example.feature.home.api.HomeDestination
+
 
 @Composable
-fun OrderScreenContent(uiState: Any) {
+fun OrderScreen(
+    viewModel: OrderViewModel,
+    onNavigate: (HomeDestination) -> Unit
+) {
+    val effectFlow = viewModel.uiEffect
 
+    // Handle effects inside Compose
+    LaunchedEffect(Unit) {
+        effectFlow.collect { effect ->
+            when (effect) {
+                is OrderUiEffect.NavigateToHomeDetail -> {
+                    onNavigate(HomeDestination.Detail(effect.homeId))
+                }
+            }
+        }
+    }
+
+    OrderScreenContent(
+        onViewHomeClick = { homeId: Int ->
+            viewModel.onIntent(
+                OrderUiIntent.OnViewHomeDetailClicked(homeId)
+            )
+        }
+    )
 }
-*/
+
+
+@Composable
+fun OrderScreenContent(
+    onViewHomeClick: (Int) -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        Text("Order Screen", style = MaterialTheme.typography.h4)
+        Spacer(modifier = Modifier.height(24.dp))
+        Button(onClick = { onViewHomeClick(7) }) {
+            Text("View Home Details")
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun OrderScreenContentPreview() {
+    MaterialTheme {
+        OrderScreenContent(
+            onViewHomeClick = {}
+        )
+    }
+}
+
+

--- a/feature/order/impl/src/main/java/com/example/feature/order/impl/ui/orderlist/OrderUiEffect.kt
+++ b/feature/order/impl/src/main/java/com/example/feature/order/impl/ui/orderlist/OrderUiEffect.kt
@@ -1,0 +1,7 @@
+package com.example.feature.order.impl.ui.orderlist
+
+sealed interface OrderUiEffect {
+    data class NavigateToHomeDetail(
+        val homeId: Int
+    ) : OrderUiEffect
+}

--- a/feature/order/impl/src/main/java/com/example/feature/order/impl/ui/orderlist/OrderUiIntent.kt
+++ b/feature/order/impl/src/main/java/com/example/feature/order/impl/ui/orderlist/OrderUiIntent.kt
@@ -1,0 +1,6 @@
+package com.example.feature.order.impl.ui.orderlist
+
+sealed interface OrderUiIntent {
+    data class OnViewHomeDetailClicked(val homeId: Int) : OrderUiIntent
+}
+

--- a/feature/order/impl/src/main/java/com/example/feature/order/impl/ui/orderlist/OrderViewModel.kt
+++ b/feature/order/impl/src/main/java/com/example/feature/order/impl/ui/orderlist/OrderViewModel.kt
@@ -1,8 +1,13 @@
 package com.example.feature.order.impl.ui.orderlist
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.example.feature.order.api.domain.usecase.GetOrderDetailsUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
@@ -10,24 +15,16 @@ class OrderViewModel @Inject constructor(
     private val getOrderDetailsUseCase: GetOrderDetailsUseCase
 ) : ViewModel() {
 
-/*    private val _uiState = MutableStateFlow<OrderUiState>(OrderUiState.Loading)
-    val uiState: StateFlow<OrderUiState> = _uiState.asStateFlow()
+    private val _uiEffect = MutableSharedFlow<OrderUiEffect>()
+    val uiEffect: SharedFlow<OrderUiEffect> = _uiEffect.asSharedFlow()
 
-    init {
-        fetchHomeItems()
-    }
-
-    private fun fetchHomeItems() {
-        viewModelScope.launch {
-            when (val result = getOrderDetailsUseCase.getOrder()) {
-
+    fun onIntent(intent: OrderUiIntent) {
+        when (intent) {
+            is OrderUiIntent.OnViewHomeDetailClicked -> {
+                viewModelScope.launch {
+                    _uiEffect.emit(OrderUiEffect.NavigateToHomeDetail(intent.homeId))
+                }
             }
         }
-    }*/
+    }
 }
-
-/*sealed class OrderUiState {
-    data object Loading : OrderUiState()
-    data class Success(val items: List<OrderItem>) : OrderUiState()
-    data class Error(val message: String) : OrderUiState()
-}*/


### PR DESCRIPTION
- Implemented sealed MVI-based navigation intent from Order to HomeDetail
- Added HomeNavigator sealed contract and intentFor() usage
- OrderViewModel emits UiEffect for navigation with homeId
- OrderFragment triggers navigation using injected HomeNavigator
- HomeDetailFragment handles back press safely for both NavController and Activity host
- Updated README with dual-hosted fragment handling strategy