### PR TITLE
Task/centralize dependencies

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,42 @@
+Project Name: Pluggo Modular Template
+
+Description: A scalable, testable Android application template using a hybrid modular architecture. It showcases feature isolation, bottom navigation with independent back stacks, internal and cross-feature navigation via sealed contracts, and modern UI with Compose inside fragments.
+
+Primary Language: Kotlin
+
+Architecture: Modular Clean Architecture with MVVM, Hilt DI, feature isolation (API, Impl, Wiring), and hybrid navigation (Fragment + Activity-based sealed contracts).
+
+Key Libraries & Frameworks:
+
+UI: Jetpack Compose (inside Fragments), Material 3, ViewBinding (for Activities)
+
+Asynchronicity: Kotlin Coroutines + Flow
+
+Dependency Injection: Hilt with multibindings
+
+Database: Not specified (can be plugged via Wiring, not present in template)
+
+Networking: Custom ApiResult sealed class abstraction (no Retrofit/OkHttp included yet)
+
+Navigation: Jetpack Navigation Component with XML graphs (Fragment-based per feature), sealed contract-based cross-feature Activity navigation
+
+Testing: JUnit for unit testing, AndroidX Test for instrumented tests
+
+2. Coding Style and Conventions
+Null Safety: Strict Kotlin null-safety is followed across all modules. Nullable types are used explicitly when required.
+
+Immutability: Preferential use of val and data class for state objects and model layers.
+
+Formatting: Kotlin official style with .kts build scripts, consistent 2-space indentation. Compose components follow clear structure with preview support.
+
+Naming:
+
+Modules: feature/<name>/{api,impl,wiring,demo}
+
+Interfaces: *Entry, *Navigator, *UseCase
+
+UI: HomeScreen, HomeFragment, HomeViewModel, UiIntent, UiEffect, UiState
+
+Navigation: Sealed Destination interfaces per feature (e.g., HomeDestination)
+
+DI: Dagger bindings via @Binds @IntoSet in Wiring modules

--- a/README.md
+++ b/README.md
@@ -318,6 +318,41 @@ git clone https://github.com/yourorg/android-modular-architecture.git
 
 ---
 
+## 📦 Dependency Management
+
+This project centralizes dependency management using Gradle's `libs.versions.toml` file. This approach offers several benefits:
+
+*   **Consistency**: All modules use the same version of a library, preventing version conflicts.
+*   **Easier Updates**: Update dependencies in one place, simplifying maintenance.
+*   **Readability**: Clearly defined aliases for dependencies improve build script readability.
+
+You can find all defined versions, libraries, and plugins in `gradle/libs.versions.toml`.
+
+---
+
+## 🏗️ Build Logic
+
+This project utilizes a `build-logic` module to encapsulate custom Gradle plugins and build configurations. This approach offers several advantages:
+
+*   **Reusability**: Share common build logic across multiple modules, reducing duplication.
+*   **Maintainability**: Centralize complex build configurations, making them easier to manage and update.
+*   **Consistency**: Ensure consistent application of build rules and dependencies throughout the project.
+
+Custom plugins defined in `build-logic` are applied to relevant modules to enforce project standards and streamline the build process.
+
+### Custom Gradle Plugins: `api`, `impl`, `demo`, and `wiring`
+
+To enforce the modular architecture and dependency rules, this project utilizes custom Gradle plugins for each module type:
+
+*   **`api` Plugin**: Applied to API modules (e.g., `feature/home/api`). This plugin ensures that API modules only expose interfaces and data models, preventing the accidental leakage of implementation details.
+*   **`impl` Plugin**: Applied to implementation modules (e.g., `feature/home/impl`). This plugin manages dependencies for implementation modules, ensuring they correctly depend on their corresponding API modules and other necessary libraries, while preventing direct dependencies on other feature's `impl` modules.
+*   **`demo` Plugin**: Applied to demo modules (e.g., `feature/home/demo`). This plugin configures demo applications, allowing them to run independently and showcase specific features.
+*   **`wiring` Plugin**: Applied to wiring modules (e.g., `feature/home/wiring`). This plugin handles the dependency injection setup for features, ensuring proper binding of APIs to their implementations.
+
+These plugins help maintain strict separation of concerns and enforce the architectural rules outlined in this README.
+
+---
+
 ## 🆕 Recent Changes
 
 * ✅ Migrated from kapt to KSP for better build performance

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,6 +38,7 @@ android {
 }
 
 dependencies {
+    
     implementation(project(":feature:home:api"))
     implementation(project(":feature:home:wiring"))
     implementation(project(":feature:order:api"))

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -1,0 +1,37 @@
+
+import org.gradle.kotlin.dsl.`kotlin-dsl`
+
+plugins {
+    `kotlin-dsl`
+}
+
+repositories {
+    mavenCentral()
+    google()
+}
+
+dependencies {
+    implementation("com.android.tools.build:gradle:8.8.2")
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.0")
+}
+
+gradlePlugin {
+    plugins {
+        register("pluggo.feature.api") {
+            id = "pluggo.feature.api"
+            implementationClass = "pluggo.feature.api.FeatureApiConventionPlugin"
+        }
+        register("pluggo.feature.demo") {
+            id = "pluggo.feature.demo"
+            implementationClass = "pluggo.feature.demo.FeatureDemoConventionPlugin"
+        }
+        register("pluggo.feature.impl") {
+            id = "pluggo.feature.impl"
+            implementationClass = "pluggo.feature.impl.FeatureImplConventionPlugin"
+        }
+        register("pluggo.feature.wiring") {
+            id = "pluggo.feature.wiring"
+            implementationClass = "pluggo.feature.wiring.FeatureWiringConventionPlugin"
+        }
+    }
+}

--- a/build-logic/src/main/kotlin/pluggo/feature/api/FeatureApiConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/pluggo/feature/api/FeatureApiConventionPlugin.kt
@@ -8,7 +8,6 @@ import org.gradle.api.plugins.ExtensionAware
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.getByType
-import org.gradle.kotlin.dsl.project
 
 class FeatureApiConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) {

--- a/build-logic/src/main/kotlin/pluggo/feature/api/FeatureApiConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/pluggo/feature/api/FeatureApiConventionPlugin.kt
@@ -1,0 +1,54 @@
+package pluggo.feature.api
+
+import com.android.build.api.dsl.LibraryExtension
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.gradle.api.plugins.ExtensionAware
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.dependencies
+import org.gradle.kotlin.dsl.getByType
+import org.gradle.kotlin.dsl.project
+
+class FeatureApiConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            val pathSegments = project.path.split(":")
+            if (pathSegments.size < 3 || pathSegments[1] != "feature") {
+                throw IllegalArgumentException("This plugin should only be applied to feature modules with names like ':feature:featureName:api'")
+            }
+            val featureName = pathSegments[2]
+
+            with(pluginManager) {
+                apply("com.android.library")
+                apply("org.jetbrains.kotlin.android")
+            }
+
+            extensions.configure<LibraryExtension> {
+                namespace = "${project.group}.${project.path.replace(":", ".").substring(1)}"
+                compileSdk = 35
+
+                defaultConfig {
+                    minSdk = 24
+                }
+
+                compileOptions {
+                    sourceCompatibility = org.gradle.api.JavaVersion.VERSION_17
+                    targetCompatibility = org.gradle.api.JavaVersion.VERSION_17
+                }
+
+                (this as ExtensionAware).extensions.configure<org.jetbrains.kotlin.gradle.dsl.KotlinJvmOptions>(
+                    "kotlinOptions"
+                ) {
+                    jvmTarget = "17"
+                }
+            }
+
+            val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
+
+            dependencies {
+                // No common dependencies for API modules, as they should only define interfaces and data models.
+            }
+        }
+    }
+}

--- a/build-logic/src/main/kotlin/pluggo/feature/demo/FeatureDemoConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/pluggo/feature/demo/FeatureDemoConventionPlugin.kt
@@ -1,0 +1,99 @@
+package pluggo.feature.demo
+
+import com.android.build.api.dsl.ApplicationExtension
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.gradle.api.plugins.ExtensionAware
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.dependencies
+import org.gradle.kotlin.dsl.getByType
+
+class FeatureDemoConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            val pathSegments = project.path.split(":")
+            if (pathSegments.size < 3 || pathSegments[1] != "feature") {
+                throw IllegalArgumentException("This plugin should only be applied to feature modules with names like ':feature:featureName:demo'")
+            }
+            val featureName = pathSegments[2]
+
+            with(pluginManager) {
+                apply("com.android.application")
+                apply("org.jetbrains.kotlin.android")
+                apply("com.google.devtools.ksp")
+                apply("dagger.hilt.android.plugin")
+            }
+
+            extensions.configure<ApplicationExtension> {
+                namespace = "${project.group}.${project.path.replace(":", ".").substring(1)}"
+                compileSdk = 35
+
+                defaultConfig {
+                    minSdk = 24
+                    targetSdk = 34
+                    versionCode = 1
+                    versionName = "1.0"
+                }
+
+                buildFeatures {
+                    compose = true
+                    viewBinding = true
+                }
+
+
+                val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
+
+                composeOptions {
+                    kotlinCompilerExtensionVersion =
+                        libs.findVersion("compose").get().requiredVersion
+                }
+
+                (this as ExtensionAware).extensions.configure<org.jetbrains.kotlin.gradle.dsl.KotlinJvmOptions>(
+                    "kotlinOptions"
+                ) {
+                    jvmTarget = "17"
+                }
+
+                compileOptions {
+                    sourceCompatibility = org.gradle.api.JavaVersion.VERSION_17
+                    targetCompatibility = org.gradle.api.JavaVersion.VERSION_17
+                }
+            }
+
+            val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
+
+            dependencies {
+                add("implementation", libs.findLibrary("androidx.core").get())
+                add("implementation", libs.findLibrary("kotlin.stdlib").get())
+
+                add("implementation", libs.findLibrary("compose.ui").get())
+                add("implementation", libs.findLibrary("compose.material").get())
+
+                add("implementation", libs.findLibrary("androidx.lifecycle.viewmodel.ktx").get())
+                add(
+                    "implementation",
+                    libs.findLibrary("androidx.lifecycle.viewmodel.compose").get()
+                )
+                add("implementation", libs.findLibrary("androidx.navigation.compose").get())
+                add("implementation", libs.findLibrary("androidx.navigation.fragment.ktx").get())
+                add("implementation", libs.findLibrary("androidx.fragment.ktx").get())
+
+                add("implementation", libs.findLibrary("androidx.appcompat").get())
+                add("implementation", libs.findLibrary("material").get())
+                add("implementation", libs.findLibrary("androidx.activity").get())
+                add("implementation", libs.findLibrary("androidx.constraintlayout").get())
+                add("implementation", libs.findLibrary("androidx.lifecycle.runtime.ktx").get())
+                add("implementation", libs.findLibrary("androidx.activity.compose").get())
+                add("implementation", platform(libs.findLibrary("androidx.compose.bom").get()))
+                add("implementation", libs.findLibrary("androidx.ui.graphics").get())
+                add("implementation", libs.findLibrary("androidx.ui.tooling.preview").get())
+                add("implementation", libs.findLibrary("androidx.material3").get())
+                add("debugImplementation", libs.findLibrary("androidx.ui.tooling").get())
+                add("debugImplementation", libs.findLibrary("androidx.ui.test.manifest").get())
+                add("implementation", libs.findLibrary("hilt.android").get())
+                add("ksp", libs.findLibrary("hilt.compiler").get())
+            }
+        }
+    }
+}

--- a/build-logic/src/main/kotlin/pluggo/feature/impl/FeatureImplConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/pluggo/feature/impl/FeatureImplConventionPlugin.kt
@@ -1,0 +1,97 @@
+package pluggo.feature.impl
+
+import com.android.build.api.dsl.LibraryExtension
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.gradle.api.plugins.ExtensionAware
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.dependencies
+import org.gradle.kotlin.dsl.getByType
+
+class FeatureImplConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            val pathSegments = project.path.split(":")
+            if (pathSegments.size < 3 || pathSegments[1] != "feature") {
+                throw IllegalArgumentException("This plugin should only be applied to feature modules with names like ':feature:featureName:impl'")
+            }
+            val featureName = pathSegments[2]
+
+            with(pluginManager) {
+                apply("com.android.library")
+                apply("org.jetbrains.kotlin.android")
+                apply("com.google.devtools.ksp")
+                apply("dagger.hilt.android.plugin")
+                apply("androidx.navigation.safeargs.kotlin")
+            }
+
+            extensions.configure<LibraryExtension> {
+                namespace = "${project.group}.${project.path.replace(":", ".").substring(1)}"
+                compileSdk = 35
+
+                defaultConfig {
+                    minSdk = 24
+                }
+
+                buildFeatures {
+                    compose = true
+                }
+
+
+                val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
+
+                composeOptions {
+                    kotlinCompilerExtensionVersion =
+                        libs.findVersion("compose").get().requiredVersion
+                }
+
+                (this as ExtensionAware).extensions.configure<org.jetbrains.kotlin.gradle.dsl.KotlinJvmOptions>(
+                    "kotlinOptions"
+                ) {
+                    jvmTarget = "17"
+                }
+
+                compileOptions {
+                    sourceCompatibility = org.gradle.api.JavaVersion.VERSION_17
+                    targetCompatibility = org.gradle.api.JavaVersion.VERSION_17
+                }
+            }
+
+            val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
+
+            dependencies {
+                add("api", libs.findLibrary("kotlinx.coroutines.core").get())
+
+                add("implementation", libs.findLibrary("androidx.core").get())
+                add("implementation", libs.findLibrary("kotlin.stdlib").get())
+                add("implementation", libs.findLibrary("compose.ui").get())
+                add("implementation", libs.findLibrary("compose.material").get())
+                add("implementation", libs.findLibrary("androidx.navigation.compose").get())
+                add("implementation", libs.findLibrary("androidx.fragment.ktx").get())
+                add("implementation", libs.findLibrary("androidx.navigation.fragment.ktx").get())
+
+                add("implementation", libs.findLibrary("androidx.lifecycle.viewmodel.ktx").get())
+                add(
+                    "implementation",
+                    libs.findLibrary("androidx.lifecycle.viewmodel.compose").get()
+                )
+                add("implementation", libs.findLibrary("androidx.ui.tooling.preview").get())
+                add("debugImplementation", libs.findLibrary("androidx.ui.tooling").get())
+
+                add("implementation", libs.findLibrary("androidx.appcompat").get())
+                add("implementation", libs.findLibrary("material").get())
+                add("implementation", libs.findLibrary("androidx.activity").get())
+                add("implementation", libs.findLibrary("androidx.constraintlayout").get())
+                add("implementation", libs.findLibrary("androidx.lifecycle.runtime.ktx").get())
+                add("implementation", libs.findLibrary("androidx.activity.compose").get())
+                add("implementation", platform(libs.findLibrary("androidx.compose.bom").get()))
+                add("implementation", libs.findLibrary("androidx.ui.graphics").get())
+                add("implementation", libs.findLibrary("androidx.material3").get())
+
+                add("implementation", libs.findLibrary("hilt.android").get())
+                add("ksp", libs.findLibrary("hilt.compiler").get())
+            }
+        }
+    }
+}

--- a/build-logic/src/main/kotlin/pluggo/feature/wiring/FeatureWiringConventionPlugin.kt
+++ b/build-logic/src/main/kotlin/pluggo/feature/wiring/FeatureWiringConventionPlugin.kt
@@ -1,0 +1,72 @@
+package pluggo.feature.wiring
+
+import com.android.build.api.dsl.LibraryExtension
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.gradle.api.plugins.ExtensionAware
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.dependencies
+import org.gradle.kotlin.dsl.getByType
+
+class FeatureWiringConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            val pathSegments = project.path.split(":")
+            if (pathSegments.size < 3 || pathSegments[1] != "feature") {
+                throw IllegalArgumentException("This plugin should only be applied to feature modules with names like ':feature:featureName:wiring'")
+            }
+            val featureName = pathSegments[2]
+
+            with(pluginManager) {
+                apply("com.android.library")
+                apply("org.jetbrains.kotlin.android")
+                apply("com.google.devtools.ksp")
+                apply("dagger.hilt.android.plugin")
+            }
+
+            extensions.configure<LibraryExtension> {
+                namespace = "${project.group}.${project.path.replace(":", ".").substring(1)}"
+                compileSdk = 35
+
+                defaultConfig {
+                    minSdk = 24
+                    testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+                    consumerProguardFiles("consumer-rules.pro")
+                }
+
+                buildTypes {
+                    release {
+                        isMinifyEnabled = false
+                        proguardFiles(
+                            getDefaultProguardFile("proguard-android-optimize.txt"),
+                            "proguard-rules.pro"
+                        )
+                    }
+                }
+
+                (this as ExtensionAware).extensions.configure<org.jetbrains.kotlin.gradle.dsl.KotlinJvmOptions>(
+                    "kotlinOptions"
+                ) {
+                    jvmTarget = "17"
+                }
+
+                compileOptions {
+                    sourceCompatibility = org.gradle.api.JavaVersion.VERSION_17
+                    targetCompatibility = org.gradle.api.JavaVersion.VERSION_17
+                }
+            }
+
+            val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
+
+            dependencies {
+
+                add("implementation", libs.findLibrary("hilt.android").get())
+                add("ksp", libs.findLibrary("hilt.compiler").get())
+                add("testImplementation", libs.findLibrary("junit").get())
+                add("androidTestImplementation", libs.findLibrary("androidx.junit").get())
+                add("androidTestImplementation", libs.findLibrary("androidx.espresso.core").get())
+            }
+        }
+    }
+}

--- a/core/src/main/res/values/colors.xml
+++ b/core/src/main/res/values/colors.xml
@@ -1,0 +1,8 @@
+<resources>
+    <color name="purple_500">#6200EE</color>
+    <color name="purple_700">#3700B3</color>
+    <color name="white">#FFFFFF</color>
+    <color name="pluggo_primary">#00E676</color>
+    <color name="gray_400">#BDBDBD</color>
+    <color name="colorPrimaryDark">#3700B3</color>
+</resources>

--- a/feature/home/api/build.gradle.kts
+++ b/feature/home/api/build.gradle.kts
@@ -1,24 +1,5 @@
 plugins {
-    id("com.android.library")
-    alias(libs.plugins.kotlin.android)
-}
-
-android {
-    namespace = "com.example.feature.home.api"
-    compileSdk = 35
-
-    defaultConfig {
-        minSdk = 24
-    }
-
-    kotlinOptions {
-        jvmTarget = "17"
-    }
-
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
+    id("pluggo.feature.api")
 }
 
 dependencies {

--- a/feature/home/demo/build.gradle.kts
+++ b/feature/home/demo/build.gradle.kts
@@ -1,8 +1,5 @@
 plugins {
-    id("com.android.application")
-    alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.ksp)
-    alias(libs.plugins.dagger.hilt.android)
+    id("pluggo.feature.demo")
 }
 
 android {
@@ -23,7 +20,8 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion = libs.versions.compose.get()
+        val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
+        kotlinCompilerExtensionVersion = libs.findVersion("compose").get().requiredVersion
     }
 
     kotlinOptions {
@@ -37,38 +35,7 @@ android {
 }
 
 dependencies {
-    // Core utilities
     implementation(project(":core"))
     implementation(project(":feature:home:api"))
     implementation(project(":feature:home:wiring"))
-
-    implementation(libs.androidx.core)
-    implementation(libs.kotlin.stdlib)
-
-    // Compose
-    implementation(libs.compose.ui)
-    implementation(libs.compose.material)
-
-    implementation(libs.androidx.lifecycle.viewmodel.ktx)
-    implementation(libs.androidx.lifecycle.viewmodel.compose)
-
-    implementation(libs.androidx.navigation.compose)
-    implementation(libs.androidx.navigation.fragment.ktx)
-    implementation(libs.androidx.fragment.ktx)
-
-    // Hilt
-    implementation(libs.androidx.appcompat)
-    implementation(libs.material)
-    implementation(libs.androidx.activity)
-    implementation(libs.androidx.constraintlayout)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
-    implementation(libs.androidx.activity.compose)
-    implementation(platform(libs.androidx.compose.bom))
-    implementation(libs.androidx.ui.graphics)
-    implementation(libs.androidx.ui.tooling.preview)
-    implementation(libs.androidx.material3)
-    debugImplementation(libs.androidx.ui.tooling)
-    debugImplementation(libs.androidx.ui.test.manifest)
-    implementation(libs.hilt.android)
-    ksp(libs.hilt.compiler)
 }

--- a/feature/home/impl/build.gradle.kts
+++ b/feature/home/impl/build.gradle.kts
@@ -1,9 +1,5 @@
 plugins {
-    id("com.android.library")
-    alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.ksp)
-    alias(libs.plugins.dagger.hilt.android)
-    alias(libs.plugins.androidx.navigation.safe.args)
+    id("pluggo.feature.impl")
 }
 
 android {
@@ -19,7 +15,8 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion = libs.versions.compose.get()
+        val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
+        kotlinCompilerExtensionVersion = libs.findVersion("compose").get().requiredVersion
     }
 
     kotlinOptions {
@@ -35,32 +32,4 @@ android {
 dependencies {
     implementation(project(":feature:home:api"))
     implementation(project(":core"))
-
-    api(libs.kotlinx.coroutines.core)
-
-    implementation(libs.androidx.core)
-    implementation(libs.kotlin.stdlib)
-    implementation(libs.compose.ui)
-    implementation(libs.compose.material)
-    implementation(libs.androidx.navigation.compose)
-    implementation(libs.androidx.fragment.ktx)
-    implementation(libs.androidx.navigation.fragment.ktx)
-
-    implementation(libs.androidx.lifecycle.viewmodel.ktx)
-    implementation(libs.androidx.lifecycle.viewmodel.compose)
-    implementation(libs.androidx.ui.tooling.preview)
-    debugImplementation(libs.androidx.ui.tooling)
-
-    implementation(libs.androidx.appcompat)
-    implementation(libs.material)
-    implementation(libs.androidx.activity)
-    implementation(libs.androidx.constraintlayout)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
-    implementation(libs.androidx.activity.compose)
-    implementation(platform(libs.androidx.compose.bom))
-    implementation(libs.androidx.ui.graphics)
-    implementation(libs.androidx.material3)
-
-    implementation(libs.hilt.android)
-    ksp(libs.hilt.compiler)
 }

--- a/feature/home/wiring/build.gradle.kts
+++ b/feature/home/wiring/build.gradle.kts
@@ -1,49 +1,9 @@
 plugins {
-    alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.ksp)
-    alias(libs.plugins.dagger.hilt.android)
-}
-
-android {
-    namespace = "com.example.feature.home.wiring"
-    compileSdk = 35
-
-    defaultConfig {
-        minSdk = 24
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        consumerProguardFiles("consumer-rules.pro")
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
-            )
-        }
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
-    kotlinOptions {
-        jvmTarget = "17"
-    }
+    id("pluggo.feature.wiring")
 }
 
 dependencies {
     api(project(":feature:home:api"))
     api(project(":feature:home:impl"))
     implementation(project(":core"))
-
-    // Hilt
-    implementation(libs.hilt.android)
-    ksp(libs.hilt.compiler)
-
-    // Testing
-    testImplementation(libs.junit)
-    androidTestImplementation(libs.androidx.junit)
-    androidTestImplementation(libs.androidx.espresso.core)
 } 

--- a/feature/order/api/build.gradle.kts
+++ b/feature/order/api/build.gradle.kts
@@ -1,24 +1,5 @@
 plugins {
-    id("com.android.library")
-    alias(libs.plugins.kotlin.android)
-}
-
-android {
-    namespace = "com.example.feature.order.api"
-    compileSdk = 35
-
-    defaultConfig {
-        minSdk = 24
-    }
-
-    kotlinOptions {
-        jvmTarget = "17"
-    }
-
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
+    id("pluggo.feature.api")
 }
 
 dependencies {

--- a/feature/order/impl/build.gradle.kts
+++ b/feature/order/impl/build.gradle.kts
@@ -1,9 +1,5 @@
 plugins {
-    id("com.android.library")
-    alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.ksp)
-    alias(libs.plugins.dagger.hilt.android)
-    alias(libs.plugins.androidx.navigation.safe.args)
+    id("pluggo.feature.impl")
 }
 
 android {
@@ -19,7 +15,8 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion = libs.versions.compose.get()
+        val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
+        kotlinCompilerExtensionVersion = libs.findVersion("compose").get().requiredVersion
     }
 
     kotlinOptions {
@@ -33,35 +30,7 @@ android {
 }
 
 dependencies {
-    api(project(":feature:order:api"))
+    implementation(project(":feature:order:api"))
     implementation(project(":feature:home:api"))
     implementation(project(":core"))
-
-    api(libs.kotlinx.coroutines.core)
-
-    implementation(libs.androidx.core)
-    implementation(libs.kotlin.stdlib)
-    implementation(libs.compose.ui)
-    implementation(libs.compose.material)
-    implementation(libs.androidx.navigation.compose)
-    implementation(libs.androidx.fragment.ktx)
-    implementation(libs.androidx.navigation.fragment.ktx)
-
-    implementation(libs.androidx.lifecycle.viewmodel.ktx)
-    implementation(libs.androidx.lifecycle.viewmodel.compose)
-    implementation(libs.androidx.ui.tooling.preview)
-    debugImplementation(libs.androidx.ui.tooling)
-
-    implementation(libs.androidx.appcompat)
-    implementation(libs.material)
-    implementation(libs.androidx.activity)
-    implementation(libs.androidx.constraintlayout)
-    implementation(libs.androidx.lifecycle.runtime.ktx)
-    implementation(libs.androidx.activity.compose)
-    implementation(platform(libs.androidx.compose.bom))
-    implementation(libs.androidx.ui.graphics)
-    implementation(libs.androidx.material3)
-
-    implementation(libs.hilt.android)
-    ksp(libs.hilt.compiler)
 }

--- a/feature/order/wiring/build.gradle.kts
+++ b/feature/order/wiring/build.gradle.kts
@@ -1,50 +1,9 @@
 plugins {
-    alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.ksp)
-    alias(libs.plugins.dagger.hilt.android)
-}
-
-android {
-    namespace = "com.example.feature.order.wiring"
-    compileSdk = 34
-
-    defaultConfig {
-        minSdk = 24
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-    }
-
-    buildTypes {
-        release {
-            isMinifyEnabled = false
-            proguardFiles(
-                getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
-            )
-        }
-    }
-
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = "17"
-    }
+    id("pluggo.feature.wiring")
 }
 
 dependencies {
     api(project(":feature:order:api"))
     api(project(":feature:order:impl"))
     implementation(project(":core"))
-
-    // Hilt
-    implementation(libs.hilt.android)
-    ksp(libs.hilt.compiler)
-
-    // Testing
-    testImplementation(libs.junit)
-    androidTestImplementation(libs.androidx.junit)
-    androidTestImplementation(libs.androidx.espresso.core)
 } 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,9 @@ fragment = "1.7.0"
 lifecycleRuntimeKtx = "2.9.0"
 activityCompose = "1.10.1"
 composeBom = "2024.09.00"
+mockito = "5.12.0"
+archTesting = "2.2.0"
+turbine = "1.1.0"
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
@@ -58,6 +61,7 @@ androidx-navigation-fragment-ktx = { module = "androidx.navigation:navigation-fr
 # Coroutines
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
+kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
 
 # Testing
 junit = { group = "junit", name = "junit", version.ref = "junit" }
@@ -65,6 +69,10 @@ androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "j
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
+mockito-core = { group = "org.mockito", name = "mockito-core", version.ref = "mockito" }
+mockito-kotlin = { group = "org.mockito.kotlin", name = "mockito-kotlin", version.ref = "mockito" }
+androidx-arch-core-testing = { group = "androidx.arch.core", name = "core-testing", version.ref = "archTesting" }
+turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine" }
 
 # AndroidX
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,5 @@
 pluginManagement {
+    includeBuild("build-logic")
     repositories {
         gradlePluginPortal()
         google()


### PR DESCRIPTION
  Introduced dedicated Gradle convention plugins for api, impl, wiring, and demo feature modules. This centralizes common build configurations and dependencies, improving scalability
  and maintainability for feature modules.


   - Created pluggo.feature.api, pluggo.feature.impl, pluggo.feature.wiring, and pluggo.feature.demo plugins.
   - Applied these plugins to home and order feature modules.
   - Removed duplicated build configurations and common dependencies from individual feature module build.gradle.kts files.
   - Corrected libs catalog access and composeOptions configuration within the new build logic plugins.
   - Removed deprecated package attribute from AndroidManifest.xml files in impl modules.
